### PR TITLE
Support package aliases

### DIFF
--- a/.changeset/tender-points-report.md
+++ b/.changeset/tender-points-report.md
@@ -1,0 +1,5 @@
+---
+"pin-dependencies-checker": minor
+---
+
+Support checking [package aliases](https://pnpm.io/aliases). For example, `"package-alias": "npm:some-package@2.26.4"`.

--- a/lib/versionIsPinned.test.ts
+++ b/lib/versionIsPinned.test.ts
@@ -35,6 +35,10 @@ describe("versionIsPinned", () => {
 		["workspace:*", false],
 		["workspace:1.0.0", true],
 		["workspace:^1.0.0", false],
+		["npm:package@2.26.4", true],
+		["npm:@scope/package@2.26.4", true],
+		["npm:package@^2.26.4", false],
+		["npm:@scope/package@^2.26.4", false],
 	])('versionIsPinned("%s") is %s', (version, expected) => {
 		expect(versionIsPinned(version)).toBe(expected);
 	});

--- a/lib/versionIsPinned.ts
+++ b/lib/versionIsPinned.ts
@@ -29,6 +29,13 @@ export function versionIsPinned(version: string) {
 		return semverPattern.test(version.substring(10));
 	}
 
+	// Support package aliases: https://pnpm.io/aliases (Also works in npm and yarn)
+	if (version.startsWith("npm:")) {
+		const aliasedVersion = version.split("@").at(-1);
+		if (!aliasedVersion) return false;
+		return semverPattern.test(aliasedVersion);
+	}
+
 	if (isUrl(version)) {
 		return (
 			containsSemverPattern.test(version) ||


### PR DESCRIPTION
Thanks for the package! It's exactly what I was looking for.

I use package aliases in the case I need to install two different versions of a particular package (crazy, I know). There are also some other use-cases.

It looks like this:
```
"some-package-2": "npm:some-package@2.26.4",
```

I found that wasn't supported, so I've added support for it here.

See https://pnpm.io/aliases
or https://classic.yarnpkg.com/lang/en/docs/cli/add/#toc-yarn-add-alias
or https://github.com/npm/rfcs/blob/main/implemented/0001-package-aliases.md