### PR TITLE
add flag to ignore versions starting with 'workspace:'

### DIFF
--- a/.changeset/rich-snails-roll.md
+++ b/.changeset/rich-snails-roll.md
@@ -1,0 +1,5 @@
+---
+"pin-dependencies-checker": minor
+---
+
+adds a flag for ignoring versions that begin with "workspace:"

--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ npx pin-checker
 
 By default, this CLI scans only `dependencies` and `devDependencies`. This behavior can be modified with CLI arguments.
 
+### `--ignore-workspaces`
+
+> Default: false
+
+Allows versions starting with `workspaces:` to be ignored:
+
+```bash
+pnpm pin-checker --ignore-workspaces
+```
+
 ### `--no-deps`
 
 > Default: false

--- a/lib/createPackage.ts
+++ b/lib/createPackage.ts
@@ -47,7 +47,11 @@ export function createPackage(pkg: GetPackage) {
 	}
 
 	for (const [dependency, version] of allDependencies.entries()) {
-		if (!versionIsPinned(version)) {
+		if (
+			!versionIsPinned(version, {
+				ignoreWorkspaces: cliConfig["ignore-workspaces"],
+			})
+		) {
 			unpinnedList.push({
 				name: dependency,
 				version,

--- a/lib/getCliConfig.ts
+++ b/lib/getCliConfig.ts
@@ -13,6 +13,10 @@ export function getCliConfig() {
 	const { values } = parseArgs({
 		args: process.argv.slice(2),
 		options: {
+			"ignore-workspaces": {
+				type: "boolean",
+				default: false,
+			},
 			"no-deps": {
 				type: "boolean",
 				default: false,

--- a/lib/lib.test.ts
+++ b/lib/lib.test.ts
@@ -286,6 +286,7 @@ describe("lib", () => {
 
 function doMockCommands(commands: Partial<CliConfigType> = {}) {
 	const defaultConfig = {
+		"ignore-workspaces": false,
 		"peer-deps": false,
 		"no-deps": false,
 		"no-dev-deps": false,

--- a/lib/versionIsPinned.test.ts
+++ b/lib/versionIsPinned.test.ts
@@ -38,4 +38,19 @@ describe("versionIsPinned", () => {
 	])('versionIsPinned("%s") is %s', (version, expected) => {
 		expect(versionIsPinned(version)).toBe(expected);
 	});
+
+	describe("ignoreWorkspaces", () => {
+		test.each([
+			["workspace:*", true],
+			["workspace:5", true],
+			["workspace:whatever", true],
+		])(
+			'versionIsPinned("%s", { ignoreWorkspaces: true }) is %s',
+			(version, expected) => {
+				expect(versionIsPinned(version, { ignoreWorkspaces: true })).toBe(
+					expected,
+				);
+			},
+		);
+	});
 });

--- a/lib/versionIsPinned.ts
+++ b/lib/versionIsPinned.ts
@@ -10,7 +10,10 @@ function isUrl(version: string): boolean {
 	return version.includes("/");
 }
 
-export function versionIsPinned(version: string) {
+export function versionIsPinned(
+	version: string,
+	options?: { ignoreWorkspaces?: boolean },
+) {
 	if (version === "" || version === "latest" || version === "*") {
 		return false;
 	}
@@ -26,6 +29,9 @@ export function versionIsPinned(version: string) {
 	}
 
 	if (version.startsWith("workspace:")) {
+		if (options?.ignoreWorkspaces) {
+			return true;
+		}
 		return semverPattern.test(version.substring(10));
 	}
 


### PR DESCRIPTION
The goal of this is to allow versions of `workspace:*` so those don't need to be updated when a package inside of a monorepo changes its version.