### PR TITLE
feat: add add option to ignore dependencies with version '*'

### DIFF
--- a/.changeset/long-ravens-say.md
+++ b/.changeset/long-ravens-say.md
@@ -1,0 +1,5 @@
+---
+"pin-dependencies-checker": patch
+---
+
+feat: add option to ignore dependencies with version "*"

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-import("../dist/pin-dependencies-checker.js");
+import("../dist/index.js");

--- a/lib/createPackage.ts
+++ b/lib/createPackage.ts
@@ -46,7 +46,7 @@ export function createPackage(pkg: GetPackage) {
 		}
 	}
 
-	if (cliConfig["check-turbo"]) {
+	if (cliConfig["ignore-star"]) {
 		for (const [dependency, version] of allDependencies.entries()) {
 			if (version === "*") {
 				allDependencies.delete(dependency);

--- a/lib/createPackage.ts
+++ b/lib/createPackage.ts
@@ -46,6 +46,14 @@ export function createPackage(pkg: GetPackage) {
 		}
 	}
 
+	if (cliConfig["check-turbo"]) {
+		for (const [dependency, version] of allDependencies.entries()) {
+			if (version === "*") {
+				allDependencies.delete(dependency);
+			}
+		}
+	}
+
 	for (const [dependency, version] of allDependencies.entries()) {
 		if (
 			!versionIsPinned(version, {

--- a/lib/getCliConfig.ts
+++ b/lib/getCliConfig.ts
@@ -37,6 +37,10 @@ export function getCliConfig() {
 				type: "boolean",
 				default: false,
 			},
+			"check-turbo": {
+				type: "boolean",
+				default: false,
+			},
 		},
 	});
 

--- a/lib/getCliConfig.ts
+++ b/lib/getCliConfig.ts
@@ -37,7 +37,7 @@ export function getCliConfig() {
 				type: "boolean",
 				default: false,
 			},
-			"check-turbo": {
+			"ignore-star": {
 				type: "boolean",
 				default: false,
 			},


### PR DESCRIPTION
Insome monorepos, internal packages list their dependencies using "\*" to simplify versioning. This PR adds an option to ignore dependencies with version "\*" during the turbo check, avoiding unnecessary errors for valid monorepo setups.