### PR TITLE
Support > node 20 and bun 1.2.10

### DIFF
--- a/.changeset/bumpy-cups-punch.md
+++ b/.changeset/bumpy-cups-punch.md
@@ -1,0 +1,5 @@
+---
+"pin-dependencies-checker": patch
+---
+
+Relax Node.js engine requirement from exact version 20 to >=20 to support newer Node versions

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
 	},
 	"packageManager": "bun@1.2.10",
 	"engines": {
-		"node": "20",
-		"bun": "1.2.10"
+		"node": ">=20",
+		"bun": ">=1.2.10"
 	},
 	"volta": {
 		"node": "20.16.0",


### PR DESCRIPTION
Thanks for creating this utility.

On my node 22 project every build I see:

```
  npm warn EBADENGINE Unsupported engine {
  npm warn EBADENGINE   package: 'pin-dependencies-checker@2.6.1',
  npm warn EBADENGINE   required: { bun: '1.2.10', node: '20' },
  npm warn EBADENGINE   current: { node: 'v22.14.0', npm: '10.9.2' }
  npm warn EBADENGINE }

```

This MR changes project support to be >node 20 and >bun 1.2.10 - which I think is a typical approach.

Please let me know if I've missed anything, I couldn't find anything that would stop this working in node 22.